### PR TITLE
[t128584][15.0][MIG] project_template: migration to 15.0

### DIFF
--- a/project_template/__manifest__.py
+++ b/project_template/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2019 Patrick Wilson <patrickraymondwilson@gmail.com>
+# License LGPLv3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+{
+    "name": "Project Templates",
+    "summary": """Project Templates""",
+    "author": "Patrick Wilson, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/project",
+    "category": "Project Management",
+    "version": "15.0.1.0.0",
+    "license": "AGPL-3",
+    "depends": ["project"],
+    "data": ["views/project.xml"],
+    "application": False,
+    "development_status": "Beta",
+    "maintainers": ["patrickrwilson"],
+}

--- a/project_template/models/project.py
+++ b/project_template/models/project.py
@@ -1,0 +1,55 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class Project(models.Model):
+    _inherit = "project.project"
+
+    is_template = fields.Boolean(copy=False)
+
+    # CREATE A PROJECT FROM A TEMPLATE AND OPEN THE NEWLY CREATED PROJECT
+    def create_project_from_template(self):
+        if " (TEMPLATE)" in self.name:
+            new_name = self.name.replace(" (TEMPLATE)", " (COPY)")
+        else:
+            new_name = self.name + " (COPY)"
+        new_project = self.copy(
+            default={"name": new_name, "active": True, "alias_name": False}
+        )
+
+        # SINCE THE END DATE DOESN'T COPY OVER ON TASKS
+        # (Even when changed to copy=true), POPULATE END DATES ON THE TASK
+        for new_task_record in new_project.task_ids:
+            for old_task_record in self.task_ids:
+                if new_task_record.name == old_task_record.name:
+                    new_task_record.date_end = old_task_record.date_end
+
+        # OPEN THE NEWLY CREATED PROJECT FORM
+        return {
+            "view_type": "form",
+            "view_mode": "form",
+            "res_model": "project.project",
+            "target": "current",
+            "res_id": new_project.id,
+            "type": "ir.actions.act_window",
+        }
+
+    # ADD "(TEMPLATE)" TO THE NAME WHEN PROJECT IS MARKED AS A TEMPLATE
+    @api.onchange("is_template")
+    def on_change_is_template(self):
+        # Add "(TEMPLATE)" to the Name if is_template == true
+        # if self.name is needed for creating projects via configuration menu
+        if self.name:
+            if self.is_template:
+                if "(TEMPLATE)" not in self.name:
+                    self.name = self.name + " (TEMPLATE)"
+                if self.user_id:
+                    self.user_id = False
+                if self.partner_id:
+                    self.partner_id = False
+                if self.alias_name:
+                    self.alias_name = False
+
+            else:
+                if " (TEMPLATE)" in self.name:
+                    self.name = self.name.replace(" (TEMPLATE)", "")

--- a/project_template/readme/CONTRIBUTORS.rst
+++ b/project_template/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* Patrick Wilson <patrickraymondwilson@gmail.com>
+* Alfadil Mustafa <alfadil.tabar@gmail.com>
+* Mantas Šniukas <mantas@vialaurea.lt>

--- a/project_template/tests/test_project_template.py
+++ b/project_template/tests/test_project_template.py
@@ -1,0 +1,63 @@
+# Copyright 2019 Patrick Wilson <patrickraymondwilson@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestProjectTemplate(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.test_customer = self.env["res.partner"].create({"name": "TestCustomer"})
+        self.test_project = self.env["project.project"].create(
+            {
+                "name": "TestProject",
+                "alias_name": "test_alias",
+                "partner_id": self.test_customer.id,
+            }
+        )
+        self.env["project.task"].create(
+            {"name": "TestTask", "project_id": self.test_project.id}
+        )
+
+    # TEST 01: Set project to be a template and test name change
+    def test_on_change_is_template(self):
+        # Test when changing project to a template
+        project_01 = self.test_project
+        project_01.is_template = True
+        project_01.on_change_is_template()
+        self.assertEqual(project_01.name, "TestProject (TEMPLATE)")
+
+        # Test when changing template back to project
+        project_01.is_template = False
+        project_01.on_change_is_template()
+        self.assertEqual(project_01.name, "TestProject")
+
+    # TEST 02: Create project from template
+    def test_create_project_from_template(self):
+        # Set Project Template
+        project_01 = self.test_project
+        project_01.is_template = True
+        project_01.on_change_is_template()
+
+        # Create new Project from Template
+        project_01.create_project_from_template()
+        new_project = self.env["project.project"].search(
+            [("name", "=", "TestProject (COPY)")]
+        )
+        self.assertEqual(len(new_project), 1)
+
+    # TEST 03: Create project from template using non-standard name
+    def test_create_project_from_template_non_standard_name(self):
+        # Set Project Template
+        project_01 = self.test_project
+        project_01.is_template = True
+        project_01.on_change_is_template()
+        # Change the name of project template
+        project_01.name = "TestProject(TEST)"
+
+        # Create new Project from Template
+        project_01.create_project_from_template()
+        new_project = self.env["project.project"].search(
+            [("name", "=", "TestProject(TEST) (COPY)")]
+        )
+        self.assertEqual(len(new_project), 1)

--- a/project_template/views/project.xml
+++ b/project_template/views/project.xml
@@ -1,0 +1,76 @@
+<odoo>
+    <!-- Form View -->
+    <record id="project_template_view_inherit_form" model="ir.ui.view">
+        <field name="name">project.template.form</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project" />
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button
+                    string="Create Project From Template"
+                    type="object"
+                    name="create_project_from_template"
+                    class="oe_highlight"
+                    attrs="{'invisible': [('is_template', '=', False)]}"
+                />
+            </xpath>
+            <xpath expr="//field[@name='label_tasks']/.." position="inside">
+                <div>
+                    <field name="is_template" class="oe_inline" string="Is Template?" />
+                    <label for="is_template" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+    <!-- Kanban View -->
+    <record id="project_template_view_inherit_kanban" model="ir.ui.view">
+        <field name="name">project.template.kanban</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.view_project_kanban" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//div[hasclass('o_kanban_card_manage_section')]"
+                position="inside"
+            >
+                <field name="is_template" invisible="1" />
+                <div t-if="record.is_template.raw_value" role="menuitem">
+                    <a
+                        name="create_project_from_template"
+                        type="object"
+                    >Create Project from Template</a>
+                </div>
+            </xpath>
+        </field>
+    </record>
+    <!-- Search View -->
+    <record id="project_template_view_inherit_search" model="ir.ui.view">
+        <field name="name">project.template.filter</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.view_project_project_filter" />
+        <field name="arch" type="xml">
+            <filter name="inactive" position="before">
+                <filter
+                    string="Templates"
+                    name="templates"
+                    domain="[('is_template', '=', True)]"
+                />
+                <filter
+                    string="Non-Templates"
+                    name="projects"
+                    domain="[('is_template', '=', False)]"
+                />
+                <separator />
+            </filter>
+        </field>
+    </record>
+    <record model="ir.actions.act_window" id="project.open_view_project_all">
+        <field name="name">Projects</field>
+        <field name="res_model">project.project</field>
+        <field name="view_id" ref="project.view_project_kanban" />
+        <field name="view_mode">kanban,form,tree</field>
+        <field
+            name="context"
+        >{"search_default_projects":1, "search_default_not_closed":1}</field>
+    </record>
+</odoo>

--- a/setup/project_template/odoo/addons/project_template
+++ b/setup/project_template/odoo/addons/project_template
@@ -1,0 +1,1 @@
+../../../../project_template

--- a/setup/project_template/setup.py
+++ b/setup/project_template/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Cherry-picks the two commits that do the migration of the module project_template to V15:

- https://github.com/OCA/project/pull/887/commits/69503ceeace4e9084f917c722728499e2b11f3b0
- https://github.com/OCA/project/pull/887/commits/7fc03bebf6be5a005bd6644ff68c6981402fb0ca
- 

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=project.task&id=128584">[t128584] [t305]  [t247][t218] Install OCA repo</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>project_template</td><td>.xml, .py, .rst</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->